### PR TITLE
FIX: Handle duplicate rows in migration

### DIFF
--- a/db/migrate/20211202134547_migrate_office365_user_info.rb
+++ b/db/migrate/20211202134547_migrate_office365_user_info.rb
@@ -21,6 +21,7 @@ class MigrateOffice365UserInfo < ActiveRecord::Migration[6.1]
       updated_at
     FROM oauth2_user_infos
     WHERE provider = 'microsoft_office365'
+    ON CONFLICT DO NOTHING
     SQL
   end
 


### PR DESCRIPTION
The previous table (`oauth2_user_infos`) didn't have a unique index on `provider`/`user_id`, so race conditions could lead to duplicate rows. This is extremely rare, so we can just keep the first and discard any others.