### PR TITLE
DEV: Delete old data from oauth2_user_infos table

### DIFF
--- a/db/post_migrate/20211230152430_remove_old_office365_data.rb
+++ b/db/post_migrate/20211230152430_remove_old_office365_data.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+class RemoveOldOffice365Data < ActiveRecord::Migration[6.1]
+  def up
+    execute "DELETE FROM oauth2_user_infos WHERE provider = 'microsoft_office365'"
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
This was migrated to `user_associated_accounts` in d457565a